### PR TITLE
BKAM-3: Duplicate key crash fix

### DIFF
--- a/BluetoothKiller/BluetoothMenuBarCoordinator.swift
+++ b/BluetoothKiller/BluetoothMenuBarCoordinator.swift
@@ -19,7 +19,7 @@ import NotificationCenter
 //    var launchConfig: LoginLaunchInterface
 
     init() {
-        deviceConnections = Dictionary(uniqueKeysWithValues: IOBluetoothDevice.devices.map({ ($0.name, $0.isConnected()) }))
+        deviceConnections = Dictionary(IOBluetoothDevice.devices.map({ ($0.name, $0.isConnected()) }), uniquingKeysWith: { $1 })
         IOBluetoothDevice.register(forConnectNotifications: self, selector: #selector(connect))
         IOBluetoothDevice.devices.forEach({ $0.register(forDisconnectNotification: self, selector: #selector(disconnect)) })
  


### PR DESCRIPTION
## Related Tickets:
[BKAM-3](https://bluetoothkiller.atlassian.net/browse/BKAM-3)

## Implementation:
The App was crashing when the same device name occurred more than once on the device list leading to duplicate keys in `deviceConnections`.
Now uses `Dictionary(_:uniquingKeysWith:)`.