### PR TITLE
BKAM-12: Coordinator improvements

### DIFF
--- a/BluetoothKiller/BluetoothMenuBarCoordinator.swift
+++ b/BluetoothKiller/BluetoothMenuBarCoordinator.swift
@@ -13,38 +13,27 @@ import NotificationCenter
 @Observable class BluetoothMenuBarCoordinator {
     var deviceConnections: [String: Bool]
     private var sleeping = false
-    private var connectedDevices: [IOBluetoothDevice] {
-        IOBluetoothDevice.devices.filter({ deviceConnections[$0.name] ?? false })
-    }
 //    var launchConfig: LoginLaunchInterface
 
     init() {
         deviceConnections = Dictionary(IOBluetoothDevice.devices.map({ ($0.name, $0.isConnected()) }), uniquingKeysWith: { $1 })
-        IOBluetoothDevice.register(forConnectNotifications: self, selector: #selector(connect))
-        IOBluetoothDevice.devices.forEach({ $0.register(forDisconnectNotification: self, selector: #selector(disconnect)) })
+        IOBluetoothDevice.register(forConnectNotifications: self, selector: #selector(onConnection(notification:from:)))
+        IOBluetoothDevice.devices.forEach({ $0.register(forDisconnectNotification: self, selector: #selector(onConnection(notification:from:))) })
  
-        NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(wake), name: NSWorkspace.screensDidWakeNotification, object: nil)
-        NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(sleep), name: NSWorkspace.screensDidSleepNotification, object: nil)
+        [NSWorkspace.screensDidWakeNotification, NSWorkspace.screensDidSleepNotification].forEach { name in
+            NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(onScreen(notification:)), name: name, object: nil)
+        }
 //        launchConfig = LoginLaunchInterface()
     }
     
-    @objc private func connect(notification: IOBluetoothUserNotification, device: IOBluetoothDevice) {
-        deviceConnections[device.name] = true
+    @objc private func onConnection(notification: IOBluetoothUserNotification, from device: IOBluetoothDevice) {
+        if !sleeping { deviceConnections[device.name] = notification.className == "IOBluetoothConcreteUserNotification" }
     }
 
-    @objc private func disconnect(notification: IOBluetoothUserNotification, device: IOBluetoothDevice) {
-        if !sleeping {
-            deviceConnections[device.name] = false
+    @objc private func onScreen(notification: NSNotification) {
+        sleeping = notification.name == NSWorkspace.screensDidSleepNotification
+        IOBluetoothDevice.devices.filter({ deviceConnections[$0.name] == true }).forEach { device in
+            sleeping ? device.closeConnection() : device.openConnection()
         }
-    }
-
-    @objc private func wake(notification: NSNotification) {
-        sleeping = false
-        connectedDevices.forEach({ $0.openConnection() })
-    }
-
-    @objc private func sleep(notification: NSNotification) {
-        sleeping = true
-        connectedDevices.forEach({ $0.closeConnection() })
     }
 }


### PR DESCRIPTION
## Related Tickets:
[BKAM-12](https://bluetoothkiller.atlassian.net/browse/BKAM-12)

## Implementation:
- Combined the `connect`/`disconnect` and `wake`/`sleep` objc functions by using the `notification` to determine the correct action.
  - Removed `connectedDevices` as the name was confusing and we only need to filter the devices in one place now.
  - Added the parameter names to the selector functions, because they make more sense that way.

I had thought about adding a convenience function for mutating an element of an `Array` and converting `deviceConnections`, but I think it actually makes more sense to leave it as a `Dictionary` even if the values become structures.  Actually the more I think about it, the more I'm thinking dictionaries are better in a lot of situations...